### PR TITLE
Fixed typo in eq for n=5

### DIFF
--- a/Book/L04andL05-Polytropes/04-Polytropes-template.ipynb
+++ b/Book/L04andL05-Polytropes/04-Polytropes-template.ipynb
@@ -186,7 +186,7 @@
         "\n",
         "For n = 5,\n",
         "\n",
-        "$$\\theta(\\epsilon) = \\frac{1.0}{(1.0+\\epsilon^{2/3})^{1/2}}$$"
+        "$$\\theta(\\epsilon) = \\frac{1.0}{(1.0+\\epsilon^{2}/3)^{1/2}}$$"
       ]
     },
     {


### PR DESCRIPTION
Fixed 

$$\theta(\epsilon) = \frac{1.0}{(1.0+\epsilon^{2/3})^{1/2}}$$

to

$$\theta(\epsilon) = \frac{1.0}{(1.0+\epsilon^{2}/3)^{1/2}}$$